### PR TITLE
Actions Ubuntu 20.04 fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 opencv-contrib-python-headless
-agpypeline
+agpypeline==0.0.50


### PR DESCRIPTION
Fixed agpypline version due to gdal update that is no longer compatible with Ubuntu 20.04